### PR TITLE
Updating broken links for Github markdown

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-![Banner](/img/banner.jpg)
+![Banner](./img/banner.jpg)
 
 # Protekt Protocol
 [Protekt Protocol](https://protektprotocol.com/) puts crypto to work insuring users against hacks, bugs, and other exploits of any DeFi protocol. Just as [Uniswap](https://uniswap.org/) allows any token to have a spot market, Protekt allows any smart contract to be insured by stakers. The goal is to support and catalyze the growth of the DeFi ecosystem by protecting users from getting rekt.
@@ -33,11 +33,11 @@ The protocol  was inspired and uses money legos from yearn, Aave, Compound, Bala
 ## How it works
 Similar to how [Uniswap](https://uniswap.org/) allows any token to have a spot market, Protekt Protocol allows any smart contract to be backed by a **Protekt contract**, which creates a market for the risk of lost assets held by the smart contract.
 
-When setting up the [Protekt contract](/protektContracts.md), the user specifies an asset (DAI, ETH, USDC, etc.) and an underlying pool, which can be a lending pool, market making pool, staking pool, multi-sig wallet, etc. They also specify the fee model and rules for triggering and evaluating a claim. Once launched, insurees get coverage by minting **pTokens** and shield miners stake assets and earn rewards for assuming the risk of getting liquidated.
+When setting up the [Protekt contract](./protektContracts.md), the user specifies an asset (DAI, ETH, USDC, etc.) and an underlying pool, which can be a lending pool, market making pool, staking pool, multi-sig wallet, etc. They also specify the fee model and rules for triggering and evaluating a claim. Once launched, insurees get coverage by minting **pTokens** and shield miners stake assets and earn rewards for assuming the risk of getting liquidated.
 
 **Protekt Protocol is a generalized and open version of the risk management systems built into Maker and Aave but can back any capital pool by anyone.**
 
-![Protocol Comparison Diagram](/img/ProtocolComparisonDiagram.png)
+![Protocol Comparison Diagram](./img/ProtocolComparisonDiagram.png)
 
 ### pTokens, like cTokens but with cover
 pTokens wrap shares in a DeFi pool (lending pool, AMM LP shares, etc.) and cover the deposits in return for an extracted fee to reward the shield miners. Let's look at an example:
@@ -46,10 +46,10 @@ Users can deposit Dai that gets forwarded into the Compound cDAI pool and get pT
 
 **In short, by holding a pToken, you pay 20% of your yield farming returns to be insured against hacks and smart contract bugs in the underlying capital pool.**
 
-![pToken Image](/img/pTokenDiagram.png)
+![pToken Image](./img/pTokenDiagram.png)
 
 ### Protekt Contracts
-[Protekt contracts](/aboutProtektContracts.md) are configurable insurance markets that can be set up on top of any smart contract. Upon launching the contract, the creator specifies:
+[Protekt contracts](./aboutProtektContracts.md) are configurable insurance markets that can be set up on top of any smart contract. Upon launching the contract, the creator specifies:
 * Underlying asset and capital pool
 * Fee model
 * Shield mining asset and investment strategy
@@ -57,22 +57,22 @@ Users can deposit Dai that gets forwarded into the Compound cDAI pool and get pT
 
 Fee models, investment strategy, and the claims process are each configurable but must conform to the same interface. Users can search for the best contract to meet their goals, and stakers can stake capital on the capital pools they are confident in. If a payout event occurs, any insuree can `submitClaim()` and kick off the claims process, which can be managed by programmatic rules, a DAO, or a centralized party.
 
-![Protekt Pool Image](/img/ProtektPool.png)
+![Protekt Pool Image](./img/ProtektPool.png)
 
 ### The PTK Mothership Pool
 The PTK Mothership is the backstop that covers all Protekt pools up to certain thresholds, governs which underlying pools are added and when, and will eventually earn cashflow. New Protekt pools can only be added through the Mothership. She creates life and gives security.
 
-![Full Protocol Image](/img/ProtektProtocolDiagram.png)
+![Full Protocol Image](./img/ProtektProtocolDiagram.png)
 
 ## The PTK Token
-The [PTK token](/ptk-token.md) is the governance and rewards token of the Protekt Protocol. It will be used to stake for assuming protocol liability, make governance decisions, receive rewards from protocol fees, provided as protocol incentives, and used to fund grants and audit reports for DeFi protocols that are covered by Protekt.
+The [PTK token](./ptk-token.md) is the governance and rewards token of the Protekt Protocol. It will be used to stake for assuming protocol liability, make governance decisions, receive rewards from protocol fees, provided as protocol incentives, and used to fund grants and audit reports for DeFi protocols that are covered by Protekt.
 
 ### Protocol Incentives (Yield Farming)
 PTK tokens can be earned by contributing capital (liquidity mining) and work, like completing tasks, writing documentation, writing code, translations, etc. 
 
-Every Wednesday, new rounds of PTK will be claimable by those completing tasks to support the protocol. Read more about protocol [contributions and rewards here](/contributions-and-rewards.md).
+Every Wednesday, new rounds of PTK will be claimable by those completing tasks to support the protocol. Read more about protocol [contributions and rewards here](./contributions-and-rewards.md).
 
-And visit the [Weekly Tasks Page](/weekly-tasks.md) to see current opportunities and start contrbuting.
+And visit the [Weekly Tasks Page](./weekly-tasks.md) to see current opportunities and start contrbuting.
 
 ### Governance
 Governance will start and end with the Protekt community. The community will not only be PTK holders but also the hackers, devs, auditors, analysts, and actuaries that contribute their blood, sweat, and tears to DeFi. They will be the ones to propose coverage of new DeFi pools, adjust and critique settings, and keep DeFi safe at night. The protocol will maintain some level of centralization at the beginning so it can iterate quickly but will pursue a pathway of [progressive decentralization](https://a16z.com/2020/01/09/progressive-decentralization-crypto-product-management/) over time.

--- a/docs/contributions-and-rewards.md
+++ b/docs/contributions-and-rewards.md
@@ -6,13 +6,13 @@ Every Wednesday, PTK tokens will be made claimable to those providing capital or
 
 When the 1st phase is started, 0.1% of PTK will be issued to those providing work to the protocol each week. Liquidity mining will not be active in the 1st phase.
 
-Visit the [Weekly Tasks Page](/weekly-tasks.md) to see the first tasks to contribute. 
+Visit the [Weekly Tasks Page](./weekly-tasks.md) to see the first tasks to contribute. 
 
 ### Contributing Work
 Tasks will be published weekly and anyone in the community is able to pick them up and complete them. Once a task is complete, open a PR on this repo for the work that was done, which will be discussed there by the community. After discussion and any iterations, if the PR is merged in, the author will be sent PTK tokens on the following Wednesday.
 
 Examples of Work include:
-* Document major DeFi hacks & exploits for the community on the [Resources Page](/resources.md).
+* Document major DeFi hacks & exploits for the community on the [Resources Page](./resources.md).
 * Complete audits and testing on DeFi projects that Protekt covers
 * Moderate and grow community forums and discussion on DeFi safety
 * Set up or build community tools to support Protekt or DeFi safety more broadly

--- a/docs/priorities.md
+++ b/docs/priorities.md
@@ -3,7 +3,7 @@
 Build a protocol and community dedicated to keeping #DeFi safe and secure for everyone. 
 
 ## Roadmap
-![Roadmap](/img/protocol-roadmap.png)
+![Roadmap](./img/protocol-roadmap.png)
 
 ## Q4 2020 OKRs
 #### Growth Objective - Find our first users.

--- a/docs/protektContracts.md
+++ b/docs/protektContracts.md
@@ -1,34 +1,34 @@
 # Protekt Contracts
 Protekt contracts are configurable insurance contracts that create a P2P market for cover and liability on top of ANY smart contract, whether it's a lending pool, market making pool, staking pool, etc. Each contract conforms to the same generalizable interface so that entering/exiting the market, fee pricing, and submitting claims is consistent and can be snapped together with other money legos.
 
-For more on Protekt Contracts, [check out the explainer page](/protektContracts/aboutProtektContracts.md).
+For more on Protekt Contracts, [check out the explainer page](./protektContracts/aboutProtektContracts.md).
 
 ## Current Protekt Contracts
 | Name | Status |
 |---------|----------|
-|[Compound DAI Manual](/protektContracts/compound-DAI-manual.md)|⌛In Progress|
+|[Compound DAI Manual](./protektContracts/compound-DAI-manual.md)|⌛In Progress|
 
 ## Modules
 
 ### Fee Models
 | Multi-sig wallet | FeeModelAutoCompoundDAI |
 |---------|----------|
-|✅Done|📆Planned|
+|✅ Done|📆 Planned|
 
 ### Investment Strategy
 | StrategyHodl | StrategyCompoundDAI | StrategyMakerDSR | StrategyUniswapWETH |
 |---------|---------|---------|---------|
-|✅Done|📆Planned|📆Planned|📆Planned|
+|✅ Done|📆 Planned|📆 Planned|📆 Planned|
 
 ### Claims Manager
 | ClaimsManagerSingleAccount | ClaimsManagerAutoCompoundDAI | ClaimsManagerNexusClaimsAssessor |
 |---------|---------|---------|
-|✅Done|📆Planned|📆Planned|
+|✅ Done|📆 Planned|📆 Planned|
 
 ### ShieldToken Withdrawals
 | PausableWithdrawals | LockUpWindowWithdrawals | ThrottledWithdrawals | FeeWithdrawals |
 |---------|---------|---------|---------|
-|⌛In Progress|📆Planned|📆Planned|📆Planned|
+|⌛ In Progress|📆 Planned|📆 Planned|📆 Planned|
 
 ## Architecture
-![Smart](/img/smartContractArchitecture.png)
+![Smart](./img/smartContractArchitecture.png)

--- a/docs/ptk-token.md
+++ b/docs/ptk-token.md
@@ -13,4 +13,4 @@ The majority of the PTK tokens will be dispersed to the community that contribut
 * 10% - Investors (if applicable)
 
 ## Earning PTK Tokens
-PTK tokens can be earned by contributing capital (liquidity mining) and work (completing tasks, documentation, development, translations, etc.). For a full overview of contributing, check out the [Contributions & Rewards Page](/contributions-and-rewards.md).
+PTK tokens can be earned by contributing capital (liquidity mining) and work (completing tasks, documentation, development, translations, etc.). For a full overview of contributing, check out the [Contributions & Rewards Page](./contributions-and-rewards.md).


### PR DESCRIPTION
I noticed that links on the Github markdown weren't working - links are absolute paths, but the files are in the `/docs/` folder. I updated all the links with relative paths, but realize that this might break docs.protektprotocol.com.

The aim is to solve the problem that people coming onto your Github to read docs will encounter broken links and images. One possible idea is the replicate the docs in `/`, so when people land they have the full documentation to read on Github, as well as on docs.protektprotocol.com, served from `/docs`. This is less ideal because it would require syncing up the two versions of the docs - in `/` and `/docs` ...

This one might not be worth the hassle right now - if so, reject - but if the relative paths work on the website it'd be an upgrade to the UX on github. 